### PR TITLE
[_]: fix podspec incorrect name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/rn-crypto",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A library for using crypto in native modules",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/rn-crypto.podspec
+++ b/rn-crypto.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name         = "RnCrypto"
+  s.name         = "rn-crypto"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]


### PR DESCRIPTION
- Fix podspec incorrect name which was causing errors during pod install/update. From RnCrypto back to rn-crypto